### PR TITLE
Added support for ctrl-l

### DIFF
--- a/src/instr.rs
+++ b/src/instr.rs
@@ -12,6 +12,7 @@ pub enum Instr {
     HistoryPrev,
     Done,
     Cancel,
+    Clear,
     Noop
 }
 
@@ -35,6 +36,7 @@ pub fn interpret_token(token: parser::Token) -> Instr {
         parser::Token::EscBracketF => Instr::MoveCursorEnd,
         parser::Token::Text        => Instr::InsertAtCursor,
         parser::Token::CtrlC       => Instr::Cancel,
+        parser::Token::CtrlL       => Instr::Clear,
         _                          => Instr::Noop
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ fn readline_edit(term: &mut Term, raw: &mut RawMode, history: &History, prompt: 
                     instr::Instr::Noop                   => (),
                     instr::Instr::Cancel                 => return Err(Error::EndOfFile),
                     instr::Instr::Clear                  => {
-                        let _ = raw.write(b"\x1b[H\x1b[2J");
+                        try!(raw.write(b"\x1b[H\x1b[2J"));
                     },
                     instr::Instr::InsertAtCursor         => buffer.insert_bytes_at_cursor(&seq)
                 };
@@ -148,10 +148,7 @@ impl Copperline {
 
     /// Clears the screen
     pub fn clear_screen(&mut self) -> Result<usize, Error> {
-        match self.term.acquire_raw_mode() {
-            Ok(mut raw) => raw.write(b"\x1b[H\x1b[2J").map_err(|e| Error::ErrNo(e)),
-            Err(e) => Err(e)
-        }
+        self.term.acquire_raw_mode().and_then(|mut raw| raw.write(b"\x1b[H\x1b[2J").map_err(|e| Error::ErrNo(e)))
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ fn readline_edit(term: &mut Term, raw: &mut RawMode, history: &History, prompt: 
                     },
                     instr::Instr::Noop                   => (),
                     instr::Instr::Cancel                 => return Err(Error::EndOfFile),
+                    instr::Instr::Clear                  => {
+                        let _ = raw.write(b"\x1b[H\x1b[2J");
+                    },
                     instr::Instr::InsertAtCursor         => buffer.insert_bytes_at_cursor(&seq)
                 };
                 seq.clear();
@@ -140,6 +143,15 @@ impl Copperline {
     /// Clears the current history.
     pub fn clear_history(&mut self) {
         self.history.clear()
+    }
+
+
+    /// Clears the screen
+    pub fn clear_screen(&mut self) -> Result<usize, Error> {
+        match self.term.acquire_raw_mode() {
+            Ok(mut raw) => raw.write(b"\x1b[H\x1b[2J").map_err(|e| Error::ErrNo(e)),
+            Err(e) => Err(e)
+        }
     }
 
 }


### PR DESCRIPTION
As well as general support for clearing with ctrl-l, a new function was
added to perform the same action, for instance when a shell runs `clear`
