### PR TITLE
add vi mode support

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -104,6 +104,15 @@ impl Buffer {
          UnicodeWidthStr::width(self.cursor().slice_before())
     }
 
+    fn move_to_pos(&mut self, pos: usize) {
+        if pos > self.front_buf.len() {
+            self.move_end();
+        }
+        else {
+            self.pos = pos;
+        }
+    }
+
     pub fn get_line(&self, prompt: &str, clear: bool) -> Vec<u8> {
         let mut line = Builder::new();
         if clear {
@@ -188,4 +197,27 @@ fn move_and_insert_cjk() {
     buf.move_left();
     buf.delete_char_left_of_cursor();
     assert_eq!(buf.to_string(), "乫䨻䦴憛".to_string());
+}
+
+#[test]
+fn move_to_pos() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("pos".to_string());
+    let pos = buf.char_pos();
+    buf.insert_chars_at_cursor("pos".to_string());
+
+    assert!(buf.char_pos() != pos);
+    buf.move_to_pos(pos);
+    assert_eq!(buf.char_pos(), pos);
+}
+
+#[test]
+fn move_to_pos_past_end() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("pos".to_string());
+    let end_pos = buf.char_pos();
+
+    assert_eq!(buf.char_pos(), end_pos);
+    buf.move_to_pos(10_000);
+    assert_eq!(buf.char_pos(), end_pos);
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -114,6 +114,10 @@ impl Buffer {
     }
 
     pub fn move_to_end_of_word(&mut self) {
+        self.vi_move_word_end();
+    }
+
+    fn vi_move_word_end(&mut self, move_mode: ViMoveMode) {
         enum State {
             Whitespace,
             EndOnWord,
@@ -133,10 +137,13 @@ impl Buffer {
 
             match state {
                 State::Whitespace => match c {
+                    // skip initial whitespace
                     c if c.is_whitespace() => {},
+                    // if we are in keyword mode and found a keyword, stop on word
                     c if is_vi_keyword(c) => {
                         state = State::EndOnWord;
                     },
+                    // in keyword mode, found non-whitespace non-keyword, stop on anything
                     _ => {
                         state = State::EndOnOther;
                     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -45,6 +45,13 @@ impl Buffer {
         }
     }
 
+    pub fn replace_chars_at_cursor(&mut self, s: String) {
+        self.delete_char_right_of_cursor();
+        let insert_len = s.chars().count();
+        self.insert_chars_at_cursor(s);
+        self.pos -= insert_len;
+    }
+
     pub fn delete_char_left_of_cursor(&mut self) {
         if self.move_left() {
             self.front_buf.remove(self.pos);
@@ -351,4 +358,20 @@ fn move_to_end_of_word_whitespace_nonkeywords() {
     assert_eq!(buf.char_pos(), end_pos1);
     buf.move_to_end_of_word();
     assert_eq!(buf.char_pos(), end_pos2);
+}
+
+#[test]
+fn replace_chars_at_cursor() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("text".to_string());
+    let pos = buf.char_pos();
+    buf.insert_chars_at_cursor(" string".to_string());
+    for _ in 0..buf.char_pos() - pos {
+        buf.move_left();
+    }
+
+    // replace should not move the cursor
+    assert_eq!(buf.char_pos(), pos);
+    buf.replace_chars_at_cursor("_".to_string());
+    assert_eq!(buf.to_string(), "text_string".to_string());
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -432,3 +432,92 @@ fn exclude_eol() {
     buf.exclude_eol();
     assert_eq!(buf.char_pos(), target);
 }
+
+#[test]
+fn move_to_end_of_word_ws_simple() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("here are".to_string());
+    let start_pos = buf.char_pos();
+    buf.insert_chars_at_cursor(" som".to_string());
+    let end_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("e words".to_string());
+    for _ in 0..buf.char_pos() - start_pos {
+        buf.move_left();
+    }
+
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos);
+}
+
+#[test]
+fn move_to_end_of_word_ws_comma() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("here ar".to_string());
+    let start_pos = buf.char_pos();
+    buf.insert_char_at_cursor('e');
+    let end_pos1 = buf.char_pos();
+    buf.insert_chars_at_cursor(", som".to_string());
+    let end_pos2 = buf.char_pos();
+    buf.insert_chars_at_cursor("e words".to_string());
+    for _ in 0..buf.char_pos() - start_pos {
+        buf.move_left();
+    }
+
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos1);
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos2);
+}
+
+#[test]
+fn move_to_end_of_word_ws_nonkeywords() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("here ar".to_string());
+    let start_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("e,,,,som".to_string());
+    let end_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("e words".to_string());
+    for _ in 0..buf.char_pos() - start_pos {
+        buf.move_left();
+    }
+
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos);
+}
+
+#[test]
+fn move_to_end_of_word_ws_whitespace() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("here are".to_string());
+    let start_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("      som".to_string());
+    let end_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("e words".to_string());
+    for _ in 0..buf.char_pos() - start_pos {
+        buf.move_left();
+    }
+
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos);
+}
+
+#[test]
+fn move_to_end_of_word_ws_whitespace_nonkeywords() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("here ar".to_string());
+    let start_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("e   ,,,".to_string());
+    let end_pos1 = buf.char_pos();
+    buf.insert_chars_at_cursor(", som".to_string());
+    let end_pos2 = buf.char_pos();
+    buf.insert_chars_at_cursor("e words".to_string());
+    for _ in 0..buf.char_pos() - start_pos {
+        buf.move_left();
+    }
+
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos1);
+    buf.move_to_end_of_word_ws();
+    assert_eq!(buf.char_pos(), end_pos2);
+}
+

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -445,11 +445,7 @@ enum ViMoveDir {
 
 /// All alphanumeric characters and _ are considered valid for keywords in vi by default.
 fn is_vi_keyword(c: char) -> bool {
-    match c {
-        '_' => true,
-        c if c.is_alphanumeric() => true,
-        _ => false,
-    }
+    c == '_' || c.is_alphanumeric()
 }
 
 #[test]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -52,9 +52,13 @@ impl Buffer {
         self.pos -= insert_len;
     }
 
-    pub fn delete_char_left_of_cursor(&mut self) {
+    pub fn delete_char_left_of_cursor(&mut self) -> bool {
         if self.move_left() {
             self.front_buf.remove(self.pos);
+            true
+        }
+        else {
+            false
         }
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -99,6 +99,12 @@ impl Buffer {
         }
     }
 
+    /// If the cursor is one past the end of the line, move one character to the left.
+    pub fn exclude_eol(&mut self) {
+        self.move_right();
+        self.move_left();
+    }
+
     pub fn move_start(&mut self) {
         self.pos = 0;
     }
@@ -374,4 +380,27 @@ fn replace_chars_at_cursor() {
     assert_eq!(buf.char_pos(), pos);
     buf.replace_chars_at_cursor("_".to_string());
     assert_eq!(buf.to_string(), "text_string".to_string());
+}
+
+#[test]
+fn exclude_eol() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("text".to_string());
+    let end = buf.char_pos();
+    buf.move_left();
+
+    let target = buf.char_pos();
+    buf.move_right();
+    buf.move_right();
+
+    // should be at the end of the string
+    assert_eq!(buf.char_pos(), end);
+
+    // a call to exclude_eol() should move the cursor
+    buf.exclude_eol();
+    assert_eq!(buf.char_pos(), target);
+
+    // further calls should not move the cursor
+    buf.exclude_eol();
+    assert_eq!(buf.char_pos(), target);
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -174,6 +174,14 @@ impl Buffer {
         self.vi_move_word_end(ViMoveMode::Whitespace, ViMoveDir::Right);
     }
 
+    pub fn move_word_back(&mut self) {
+        self.vi_move_word_end(ViMoveMode::Keyword, ViMoveDir::Left);
+    }
+
+    pub fn move_word_ws_back(&mut self) {
+        self.vi_move_word_end(ViMoveMode::Whitespace, ViMoveDir::Left);
+    }
+
     fn vi_move_word_end(&mut self, move_mode: ViMoveMode, direction: ViMoveDir) {
         enum State {
             Whitespace,
@@ -667,4 +675,63 @@ fn move_word_whitespace_nonkeywords() {
     assert_eq!(buf.char_pos(), pos1);
     buf.move_word_ws();
     assert_eq!(buf.char_pos(), pos3);
+}
+
+#[test]
+fn move_word_and_back() {
+    let mut buf = Buffer::new();
+    buf.insert_chars_at_cursor("here ".to_string());
+    let pos1 = buf.char_pos();
+    buf.insert_chars_at_cursor("are ".to_string());
+    let pos2 = buf.char_pos();
+    buf.insert_chars_at_cursor("some".to_string());
+    let pos3 = buf.char_pos();
+    buf.insert_chars_at_cursor("... ".to_string());
+    let pos4 = buf.char_pos();
+    buf.insert_chars_at_cursor("words".to_string());
+    let pos5 = buf.char_pos();
+
+    // make sure move_word() and move_word_back() are reflections of eachother
+
+    buf.move_start();
+    buf.move_word();
+    assert_eq!(buf.char_pos(), pos1);
+    buf.move_word();
+    assert_eq!(buf.char_pos(), pos2);
+    buf.move_word();
+    assert_eq!(buf.char_pos(), pos3);
+    buf.move_word();
+    assert_eq!(buf.char_pos(), pos4);
+    buf.move_word();
+    assert_eq!(buf.char_pos(), pos5);
+
+    buf.move_word_back();
+    assert_eq!(buf.char_pos(), pos4);
+    buf.move_word_back();
+    assert_eq!(buf.char_pos(), pos3);
+    buf.move_word_back();
+    assert_eq!(buf.char_pos(), pos2);
+    buf.move_word_back();
+    assert_eq!(buf.char_pos(), pos1);
+    buf.move_word_back();
+    assert_eq!(buf.char_pos(), 0);
+
+    buf.move_start();
+    buf.move_word_ws();
+    assert_eq!(buf.char_pos(), pos1);
+    buf.move_word_ws();
+    assert_eq!(buf.char_pos(), pos2);
+    buf.move_word_ws();
+    assert_eq!(buf.char_pos(), pos4);
+    buf.move_word_ws();
+    assert_eq!(buf.char_pos(), pos5);
+
+    buf.move_word_ws_back();
+    assert_eq!(buf.char_pos(), pos4);
+    buf.move_word_ws_back();
+    assert_eq!(buf.char_pos(), pos2);
+    buf.move_word_ws_back();
+    assert_eq!(buf.char_pos(), pos1);
+    buf.move_word_ws_back();
+    assert_eq!(buf.char_pos(), 0);
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -110,6 +110,10 @@ impl Buffer {
     }
 
     pub fn move_word(&mut self) {
+        self.vi_move_word();
+    }
+
+    fn vi_move_word(&mut self) {
         enum State {
             Whitespace,
             Keyword,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -441,9 +441,7 @@ fn move_to_end_of_word_ws_simple() {
     buf.insert_chars_at_cursor(" som".to_string());
     let end_pos = buf.char_pos();
     buf.insert_chars_at_cursor("e words".to_string());
-    for _ in 0..buf.char_pos() - start_pos {
-        buf.move_left();
-    }
+    buf.move_to_pos(start_pos);
 
     buf.move_to_end_of_word_ws();
     assert_eq!(buf.char_pos(), end_pos);
@@ -459,9 +457,7 @@ fn move_to_end_of_word_ws_comma() {
     buf.insert_chars_at_cursor(", som".to_string());
     let end_pos2 = buf.char_pos();
     buf.insert_chars_at_cursor("e words".to_string());
-    for _ in 0..buf.char_pos() - start_pos {
-        buf.move_left();
-    }
+    buf.move_to_pos(start_pos);
 
     buf.move_to_end_of_word_ws();
     assert_eq!(buf.char_pos(), end_pos1);
@@ -477,9 +473,7 @@ fn move_to_end_of_word_ws_nonkeywords() {
     buf.insert_chars_at_cursor("e,,,,som".to_string());
     let end_pos = buf.char_pos();
     buf.insert_chars_at_cursor("e words".to_string());
-    for _ in 0..buf.char_pos() - start_pos {
-        buf.move_left();
-    }
+    buf.move_to_pos(start_pos);
 
     buf.move_to_end_of_word_ws();
     assert_eq!(buf.char_pos(), end_pos);
@@ -493,9 +487,7 @@ fn move_to_end_of_word_ws_whitespace() {
     buf.insert_chars_at_cursor("      som".to_string());
     let end_pos = buf.char_pos();
     buf.insert_chars_at_cursor("e words".to_string());
-    for _ in 0..buf.char_pos() - start_pos {
-        buf.move_left();
-    }
+    buf.move_to_pos(start_pos);
 
     buf.move_to_end_of_word_ws();
     assert_eq!(buf.char_pos(), end_pos);
@@ -511,9 +503,7 @@ fn move_to_end_of_word_ws_whitespace_nonkeywords() {
     buf.insert_chars_at_cursor(", som".to_string());
     let end_pos2 = buf.char_pos();
     buf.insert_chars_at_cursor("e words".to_string());
-    for _ in 0..buf.char_pos() - start_pos {
-        buf.move_left();
-    }
+    buf.move_to_pos(start_pos);
 
     buf.move_to_end_of_word_ws();
     assert_eq!(buf.char_pos(), end_pos1);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -258,12 +258,32 @@ impl Buffer {
         return false;
     }
 
-    pub fn move_to_char_right(&mut self, target_c: char) -> bool {
-        self.move_to_char(target_c, ViMoveDir::Right)
+    /// Move count characters to the right.
+    ///
+    /// If count characters are not found, the position will not be changed.
+    pub fn move_to_char_right(&mut self, target_c: char, count: u32) -> bool {
+        let pos = self.char_pos();
+        for _ in 0..count {
+            if !self.move_to_char(target_c, ViMoveDir::Right) {
+                self.move_to_pos(pos);
+                return false;
+            }
+        }
+        return true;
     }
 
-    pub fn move_to_char_left(&mut self, target_c: char) -> bool {
-        self.move_to_char(target_c, ViMoveDir::Left)
+    /// Move count characters to the left.
+    ///
+    /// If count characters are not found, the position will not be changed.
+    pub fn move_to_char_left(&mut self, target_c: char, count: u32) -> bool {
+        let pos = self.char_pos();
+        for _ in 0..count {
+            if !self.move_to_char(target_c, ViMoveDir::Left) {
+                self.move_to_pos(pos);
+                return false;
+            }
+        }
+        return true;
     }
 
     fn move_to_char(&mut self, target_c: char, direction: ViMoveDir) -> bool {
@@ -778,15 +798,20 @@ fn move_to_char() {
     let mut buf = Buffer::new();
     buf.insert_chars_at_cursor("words".to_string());
     let pos1 = buf.char_pos();
-    buf.insert_chars_at_cursor(" words".to_string());
+    buf.insert_chars_at_cursor(" wor".to_string());
+    let d_pos = buf.char_pos();
+    buf.insert_chars_at_cursor("ds".to_string());
 
     buf.move_start();
-    assert!(buf.move_to_char_right(' '));
+    assert!(buf.move_to_char_right(' ', 1));
     assert_eq!(buf.char_pos(), pos1);
     buf.move_end();
-    assert!(buf.move_to_char_left(' '));
+    assert!(buf.move_to_char_left(' ', 1));
     assert_eq!(buf.char_pos(), pos1);
-    buf.move_end();
-    assert_eq!(buf.move_to_char_left('z'), false);
+    buf.move_start();
+    assert_eq!(buf.move_to_char_right('z', 1), false);
     assert_eq!(buf.char_pos(), 0);
+    buf.move_start();
+    assert!(buf.move_to_char_right('d', 2));
+    assert_eq!(buf.char_pos(), d_pos);
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -898,7 +898,7 @@ fn move_to_char() {
 }
 
 #[test]
-fn move_and_delete() {
+fn move_and_delete1() {
     // test a simple move
     let mut buf = Buffer::new();
     buf.insert_chars_at_cursor("words words words".to_string());
@@ -909,7 +909,10 @@ fn move_and_delete() {
         dc.delete();
     }
     assert_eq!(buf.to_string(), "words words".to_string());
+}
 
+#[test]
+fn move_and_delete2() {
     // test deleting an empty string
     let mut buf = Buffer::new();
     buf.move_start();
@@ -919,7 +922,10 @@ fn move_and_delete() {
         dc.delete();
     }
     assert_eq!(buf.to_string(), "".to_string());
+}
 
+#[test]
+fn move_and_delete3() {
     // test deleting from the end to the beginning
     let mut buf = Buffer::new();
     buf.insert_chars_at_cursor("words words words".to_string());

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -367,6 +367,10 @@ impl Buffer {
         self.pos = 0;
         s
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.front_buf.is_empty()
+    }
 }
 
 #[must_use]

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -12,7 +12,7 @@ pub enum EditMode {
     Vi,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum ViMode {
     Insert,
     Normal,
@@ -116,6 +116,10 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Cont(false)
                 },
                 instr::Instr::NormalMode => {
+                    if ctx.vi_mode == ViMode::Insert {
+                        // cursor moves left when leaving insert mode
+                        ctx.buf.move_left();
+                    }
                     ctx.vi_mode = ViMode::Normal;
                     Cont(false)
                 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -209,6 +209,14 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.buf.exclude_eol();
                     Cont(false)
                 }
+                instr::Instr::MoveWordLeft => {
+                    vi_repeat!(ctx, ctx.buf.move_word_back());
+                    Cont(false)
+                }
+                instr::Instr::MoveWordWsLeft => {
+                    vi_repeat!(ctx, ctx.buf.move_word_ws_back());
+                    Cont(false)
+                }
                 instr::Instr::Substitute => {
                     vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
                     ctx.vi_mode = ViMode::Insert;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -17,18 +17,20 @@ pub struct EditCtx<'a> {
     history_cursor: Cursor<'a>,
     prompt: &'a str,
     seq: Vec<u8>,
-    enc: EncodingRef
+    enc: EncodingRef,
+    mode: EditMode,
 }
 
 impl<'a> EditCtx<'a> {
 
-    pub fn new(prompt: &'a str, history: &'a History, enc: EncodingRef) -> Self {
+    pub fn new(prompt: &'a str, history: &'a History, enc: EncodingRef, mode: EditMode) -> Self {
         EditCtx {
             buf: Buffer::new(),
             history_cursor: Cursor::new(history),
             prompt: prompt,
             seq: Vec::new(),
-            enc: enc
+            enc: enc,
+            mode: mode,
         }
     }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -123,6 +123,12 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                         Cont(false)
                     }
                 },
+                instr::Instr::DeleteLine => {
+                    ctx.buf.drain();
+                    ctx.vi_mode = ViMode::Normal;
+                    ctx.vi_count = 0;
+                    Cont(false)
+                }
                 instr::Instr::MoveCursorLeft => {
                     vi_repeat!(ctx, ctx.buf.move_left());
                     Cont(false)

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -125,17 +125,21 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Cont(false)
                 },
                 instr::Instr::HistoryPrev => {
-                    if ctx.history_cursor.incr() {
-                        ctx.buf.swap()
-                    }
-                    ctx.history_cursor.get().map(|s| ctx.buf.replace(s));
+                    vi_repeat!(ctx, {
+                        if ctx.history_cursor.incr() {
+                            ctx.buf.swap()
+                        }
+                        ctx.history_cursor.get().map(|s| ctx.buf.replace(s));
+                    });
                     Cont(false)
                 },
                 instr::Instr::HistoryNext => {
-                    if ctx.history_cursor.decr() {
-                        ctx.buf.swap()
-                    }
-                    ctx.history_cursor.get().map(|s| ctx.buf.replace(s));
+                    vi_repeat!(ctx, {
+                        if ctx.history_cursor.decr() {
+                            ctx.buf.swap()
+                        }
+                        ctx.history_cursor.get().map(|s| ctx.buf.replace(s));
+                    });
                     Cont(false)
                 },
                 instr::Instr::NormalMode => {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -65,6 +65,16 @@ macro_rules! vi_repeat {
         }
         $ctx.vi_count = 0;
     };
+    ( $ctx:ident, $operation:expr, $step:expr ) => {
+        match $ctx.vi_count {
+            0 => { $operation; }
+            _ => {
+                $operation;
+                for _ in 1..$ctx.vi_count { $step; $operation; }
+            }
+        }
+        $ctx.vi_count = 0;
+    };
 }
 
 pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -19,6 +19,7 @@ pub enum ViMode {
     Normal,
     Replace,
     MoveChar(instr::CharMoveType),
+    Delete,
 }
 
 pub struct EditCtx<'a> {
@@ -183,6 +184,10 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 }
                 instr::Instr::MoveCharMode(mode) => {
                     ctx.vi_mode = ViMode::MoveChar(mode);
+                    Cont(false)
+                }
+                instr::Instr::DeleteMode => {
+                    ctx.vi_mode = ViMode::Delete;
                     Cont(false)
                 }
                 instr::Instr::Insert => {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -204,6 +204,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.buf.exclude_eol();
                     Cont(false)
                 }
+                instr::Instr::MoveWordWsRight => {
+                    vi_repeat!(ctx, ctx.buf.move_word_ws());
+                    ctx.buf.exclude_eol();
+                    Cont(false)
+                }
                 instr::Instr::Substitute => {
                     vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
                     ctx.vi_mode = ViMode::Insert;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -124,6 +124,9 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 },
                 instr::Instr::DeleteCharRightOfCursor => {
                     vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
+                    if ctx.vi_mode == ViMode::Normal {
+                        ctx.buf.exclude_eol();
+                    }
                     Cont(false)
                 },
                 instr::Instr::DeleteCharRightOfCursorOrEOF => {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -6,6 +6,12 @@ use buffer::Buffer;
 use parser::{parse, ParseError, ParseSuccess};
 use instr;
 
+#[derive(Copy,Clone)]
+pub enum EditMode {
+    Emacs,
+    Vi,
+}
+
 pub struct EditCtx<'a> {
     buf: Buffer,
     history_cursor: Cursor<'a>,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -66,7 +66,7 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
         },
         Err(ParseError::Incomplete) => Cont(false),
         Ok(ParseSuccess(token, len)) => {
-            let res = match instr::interpret_token(token) {
+            let res = match instr::interpret_token(token, ctx.mode, ctx.vi_mode) {
                 instr::Instr::Done => {
                     Halt(Ok(ctx.buf.drain()))
                 },
@@ -115,6 +115,29 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.history_cursor.get().map(|s| ctx.buf.replace(s));
                     Cont(false)
                 },
+                instr::Instr::NormalMode => {
+                    ctx.vi_mode = ViMode::Normal;
+                    Cont(false)
+                }
+                instr::Instr::Insert => {
+                    ctx.vi_mode = ViMode::Insert;
+                    Cont(false)
+                }
+                instr::Instr::InsertStart => {
+                    ctx.vi_mode = ViMode::Insert;
+                    ctx.buf.move_start();
+                    Cont(false)
+                }
+                instr::Instr::Append => {
+                    ctx.vi_mode = ViMode::Insert;
+                    ctx.buf.move_right();
+                    Cont(false)
+                }
+                instr::Instr::AppendEnd => {
+                    ctx.vi_mode = ViMode::Insert;
+                    ctx.buf.move_end();
+                    Cont(false)
+                }
                 instr::Instr::Noop => {
                     Cont(false)
                 },

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -142,6 +142,10 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.buf.move_end();
                     Cont(false)
                 }
+                instr::Instr::MoveEndOfWordRight => {
+                    ctx.buf.move_to_end_of_word();
+                    Cont(false)
+                }
                 instr::Instr::Noop => {
                     Cont(false)
                 },

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -146,6 +146,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.buf.move_to_end_of_word();
                     Cont(false)
                 }
+                instr::Instr::Substitute => {
+                    ctx.buf.delete_char_right_of_cursor();
+                    ctx.vi_mode = ViMode::Insert;
+                    Cont(false)
+                }
                 instr::Instr::Noop => {
                     Cont(false)
                 },

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -94,11 +94,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Halt(Ok(ctx.buf.drain()))
                 },
                 instr::Instr::DeleteCharLeftOfCursor => {
-                    ctx.buf.delete_char_left_of_cursor();
+                    vi_repeat!(ctx, ctx.buf.delete_char_left_of_cursor());
                     Cont(false)
                 },
                 instr::Instr::DeleteCharRightOfCursor => {
-                    ctx.buf.delete_char_right_of_cursor();
+                    vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
                     Cont(false)
                 },
                 instr::Instr::DeleteCharRightOfCursorOrEOF => {
@@ -109,11 +109,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     }
                 },
                 instr::Instr::MoveCursorLeft => {
-                    ctx.buf.move_left();
+                    vi_repeat!(ctx, ctx.buf.move_left());
                     Cont(false)
                 },
                 instr::Instr::MoveCursorRight => {
-                    ctx.buf.move_right();
+                    vi_repeat!(ctx, ctx.buf.move_right());
                     Cont(false)
                 },
                 instr::Instr::MoveCursorStart => {
@@ -184,7 +184,7 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Cont(false)
                 }
                 instr::Instr::Substitute => {
-                    ctx.buf.delete_char_right_of_cursor();
+                    vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
                     ctx.vi_mode = ViMode::Insert;
                     Cont(false)
                 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -120,10 +120,12 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Cont(false)
                 },
                 instr::Instr::MoveCursorStart => {
+                    ctx.vi_count = 0;
                     ctx.buf.move_start();
                     Cont(false)
                 },
                 instr::Instr::MoveCursorEnd => {
+                    ctx.vi_count = 0;
                     ctx.buf.move_end();
                     if ctx.vi_mode == ViMode::Normal {
                         ctx.buf.exclude_eol();

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -57,6 +57,16 @@ pub enum EditResult<C> {
     Halt(Result<String, Error>)
 }
 
+macro_rules! vi_repeat {
+    ( $ctx:ident, $x:expr ) => {
+        match $ctx.vi_count {
+            0 => { $x; }
+            _ => for _ in 0..$ctx.vi_count { $x; }
+        }
+        $ctx.vi_count = 0;
+    };
+}
+
 pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
     use self::EditResult::*;
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -194,6 +194,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.buf.exclude_eol();
                     Cont(false)
                 }
+                instr::Instr::MoveEndOfWordWsRight => {
+                    vi_repeat!(ctx, ctx.buf.move_to_end_of_word_ws());
+                    ctx.buf.exclude_eol();
+                    Cont(false)
+                }
                 instr::Instr::Substitute => {
                     vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
                     ctx.vi_mode = ViMode::Insert;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -16,6 +16,7 @@ pub enum EditMode {
 pub enum ViMode {
     Insert,
     Normal,
+    Replace,
 }
 
 pub struct EditCtx<'a> {
@@ -123,6 +124,10 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.vi_mode = ViMode::Normal;
                     Cont(false)
                 }
+                instr::Instr::ReplaceMode => {
+                    ctx.vi_mode = ViMode::Replace;
+                    Cont(false)
+                }
                 instr::Instr::Insert => {
                     ctx.vi_mode = ViMode::Insert;
                     Cont(false)
@@ -160,6 +165,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 },
                 instr::Instr::InsertAtCursor(text) => {
                     ctx.buf.insert_chars_at_cursor(text);
+                    Cont(false)
+                }
+                instr::Instr::ReplaceAtCursor(text) => {
+                    ctx.buf.replace_chars_at_cursor(text);
+                    ctx.vi_mode = ViMode::Normal;
                     Cont(false)
                 }
             };

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -12,6 +12,11 @@ pub enum EditMode {
     Vi,
 }
 
+enum ViMode {
+    Insert,
+    Normal,
+}
+
 pub struct EditCtx<'a> {
     buf: Buffer,
     history_cursor: Cursor<'a>,
@@ -19,6 +24,7 @@ pub struct EditCtx<'a> {
     seq: Vec<u8>,
     enc: EncodingRef,
     mode: EditMode,
+    vi_mode: ViMode,
 }
 
 impl<'a> EditCtx<'a> {
@@ -31,6 +37,8 @@ impl<'a> EditCtx<'a> {
             seq: Vec::new(),
             enc: enc,
             mode: mode,
+            // always start in insert mode
+            vi_mode: ViMode::Insert,
         }
     }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -170,7 +170,7 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Cont(false)
                 }
                 instr::Instr::MoveEndOfWordRight => {
-                    ctx.buf.move_to_end_of_word();
+                    vi_repeat!(ctx, ctx.buf.move_to_end_of_word());
                     Cont(false)
                 }
                 instr::Instr::Substitute => {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -199,6 +199,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.buf.exclude_eol();
                     Cont(false)
                 }
+                instr::Instr::MoveWordRight => {
+                    vi_repeat!(ctx, ctx.buf.move_word());
+                    ctx.buf.exclude_eol();
+                    Cont(false)
+                }
                 instr::Instr::Substitute => {
                     vi_repeat!(ctx, ctx.buf.delete_char_right_of_cursor());
                     ctx.vi_mode = ViMode::Insert;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -12,7 +12,8 @@ pub enum EditMode {
     Vi,
 }
 
-enum ViMode {
+#[derive(Copy, Clone)]
+pub enum ViMode {
     Insert,
     Normal,
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -119,6 +119,14 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 instr::Instr::Done => {
                     Halt(Ok(ctx.buf.drain()))
                 },
+                instr::Instr::DoneOrEof => {
+                    if ctx.buf.is_empty() {
+                        Halt(Err(Error::EndOfFile))
+                    }
+                    else {
+                        Halt(Ok(ctx.buf.drain()))
+                    }
+                }
                 instr::Instr::DeleteCharLeftOfCursor => {
                     vi_repeat!(ctx, ctx.buf.delete_char_left_of_cursor());
                     Cont(false)

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -114,6 +114,9 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 },
                 instr::Instr::MoveCursorRight => {
                     vi_repeat!(ctx, ctx.buf.move_right());
+                    if ctx.vi_mode == ViMode::Normal {
+                        ctx.buf.exclude_eol();
+                    }
                     Cont(false)
                 },
                 instr::Instr::MoveCursorStart => {
@@ -122,6 +125,9 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 },
                 instr::Instr::MoveCursorEnd => {
                     ctx.buf.move_end();
+                    if ctx.vi_mode == ViMode::Normal {
+                        ctx.buf.exclude_eol();
+                    }
                     Cont(false)
                 },
                 instr::Instr::HistoryPrev => {
@@ -185,6 +191,7 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 }
                 instr::Instr::MoveEndOfWordRight => {
                     vi_repeat!(ctx, ctx.buf.move_to_end_of_word());
+                    ctx.buf.exclude_eol();
                     Cont(false)
                 }
                 instr::Instr::Substitute => {
@@ -207,7 +214,10 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     vi_repeat!(
                         ctx,
                         ctx.buf.replace_chars_at_cursor(text.clone()),
-                        ctx.buf.move_right()
+                        {
+                            ctx.buf.move_right();
+                            ctx.buf.exclude_eol();
+                        }
                     );
                     ctx.vi_mode = ViMode::Normal;
                     Cont(false)

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -352,7 +352,20 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 instr::Instr::MoveWordRight => {
                     {
                         let mut dc = ctx.buf.start_delete();
-                        vi_delete!(ctx with dc { dc.move_word() });
+                        vi_repeat!(ctx, dc.move_word());
+                        match ctx.vi_mode {
+                            ViMode::Delete => dc.delete(),
+                            ViMode::Change => {
+                                // move word right has special behavior in change mode
+                                if !dc.started_on_whitespace() && dc.move_right() {
+                                    dc.move_to_end_of_word_back();
+                                    dc.move_right();
+                                }
+                                dc.delete();
+                            }
+                            _ => {}
+                        }
+                        set_next_vi_mode!(ctx);
                     }
                     ctx.exclude_eol();
                     Cont(false)
@@ -360,7 +373,20 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                 instr::Instr::MoveWordWsRight => {
                     {
                         let mut dc = ctx.buf.start_delete();
-                        vi_delete!(ctx with dc { dc.move_word_ws() });
+                        vi_repeat!(ctx, dc.move_word_ws());
+                        match ctx.vi_mode {
+                            ViMode::Delete => dc.delete(),
+                            ViMode::Change => {
+                                // move word right has special behavior in change mode
+                                if !dc.started_on_whitespace() && dc.move_right() {
+                                    dc.move_to_end_of_word_ws_back();
+                                    dc.move_right();
+                                }
+                                dc.delete();
+                            }
+                            _ => {}
+                        }
+                        set_next_vi_mode!(ctx);
                     }
                     ctx.exclude_eol();
                     Cont(false)

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -143,6 +143,16 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     ctx.vi_count = 0;
                     Cont(false)
                 }
+                instr::Instr::DeleteToEnd => {
+                    ctx.vi_count = 0;
+                    {
+                        ctx.vi_mode = ViMode::Delete;
+                        let mut dc = ctx.buf.start_delete();
+                        vi_delete!(ctx with dc { dc.move_end(); false });
+                    }
+                    ctx.buf.exclude_eol();
+                    Cont(false)
+                }
                 instr::Instr::MoveCursorLeft => {
                     let mut dc = ctx.buf.start_delete();
                     vi_delete!(ctx with dc { dc.move_left() });

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -200,7 +200,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                     Cont(false)
                 }
                 instr::Instr::ReplaceAtCursor(text) => {
-                    ctx.buf.replace_chars_at_cursor(text);
+                    vi_repeat!(
+                        ctx,
+                        ctx.buf.replace_chars_at_cursor(text.clone()),
+                        ctx.buf.move_right()
+                    );
                     ctx.vi_mode = ViMode::Normal;
                     Cont(false)
                 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,5 +1,6 @@
 use encoding::types::EncodingRef;
 
+use std::u32;
 use error::Error;
 use history::{Cursor, History};
 use buffer::Buffer;
@@ -203,7 +204,11 @@ pub fn edit<'a>(ctx: &mut EditCtx<'a>) -> EditResult<Vec<u8>> {
                         // if count is 0, then 0 moves to the start of a line
                         (0, 0) => ctx.buf.move_start(),
                         // otherwise add a digit to the count
-                        (_, i) => ctx.vi_count = ctx.vi_count * 10 + i,
+                        (_, i) => {
+                            if ctx.vi_count <= (u32::MAX - i) / 10 {
+                                ctx.vi_count = ctx.vi_count * 10 + i
+                            }
+                        }
                     }
                     Cont(false)
                 }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -1,4 +1,6 @@
 use parser;
+use edit::EditMode;
+use edit::ViMode;
 
 pub enum Instr {
     MoveCursorLeft,
@@ -11,13 +13,28 @@ pub enum Instr {
     InsertAtCursor(String),
     HistoryNext,
     HistoryPrev,
+    Insert,
+    InsertStart,
+    Append,
+    AppendEnd,
+    NormalMode,
     Done,
     Cancel,
     Clear,
     Noop
 }
 
-pub fn interpret_token(token: parser::Token) -> Instr {
+pub fn interpret_token(token: parser::Token, edit_mode: EditMode, vi_mode: ViMode) -> Instr {
+    match edit_mode {
+        EditMode::Emacs => emacs_mode(token),
+        EditMode::Vi => match vi_mode {
+            ViMode::Insert => vi_insert_mode(token),
+            ViMode::Normal => vi_normal_mode(token),
+        },
+    }
+}
+
+fn emacs_mode(token: parser::Token) -> Instr {
     match token {
         parser::Token::Enter        => Instr::Done,
         parser::Token::Backspace    => Instr::DeleteCharLeftOfCursor,
@@ -40,5 +57,57 @@ pub fn interpret_token(token: parser::Token) -> Instr {
         parser::Token::CtrlC        => Instr::Cancel,
         parser::Token::CtrlL        => Instr::Clear,
         _                           => Instr::Noop
+    }
+}
+
+fn vi_common(token: &parser::Token) -> Instr {
+    match *token {
+        parser::Token::Enter        => Instr::Done,
+        parser::Token::Esc          => Instr::NormalMode,
+        parser::Token::Backspace    => Instr::DeleteCharLeftOfCursor,
+        parser::Token::EscBracket3T => Instr::DeleteCharRightOfCursor,
+        // XXX EOF
+        parser::Token::CtrlD        => Instr::DeleteCharRightOfCursorOrEOF,
+        // movement keys
+        parser::Token::EscBracketA  => Instr::HistoryPrev,
+        parser::Token::EscBracketB  => Instr::HistoryNext,
+        parser::Token::EscBracketC  => Instr::MoveCursorRight,
+        parser::Token::EscBracketD  => Instr::MoveCursorLeft,
+        // home
+        parser::Token::EscBracketH  => Instr::MoveCursorStart,
+        // end
+        parser::Token::EscBracketF  => Instr::MoveCursorEnd,
+        parser::Token::CtrlC        => Instr::Cancel,
+        parser::Token::CtrlL        => Instr::Clear,
+        _                           => Instr::Noop,
+    }
+}
+
+fn vi_insert_mode(token: parser::Token) -> Instr {
+    match token {
+        parser::Token::Text(text)   => Instr::InsertAtCursor(text),
+        _                           => vi_common(&token),
+    }
+}
+fn vi_normal_mode(token: parser::Token) -> Instr {
+    match token {
+        parser::Token::Text(text)   => match text.as_ref() {
+            "h"                     => Instr::MoveCursorLeft,
+            "j"                     => Instr::HistoryNext,
+            "k"                     => Instr::HistoryPrev,
+            "l"                     => Instr::MoveCursorRight,
+            "0"                     => Instr::MoveCursorStart,
+            "$"                     => Instr::MoveCursorEnd,
+
+            "x"                     => Instr::DeleteCharRightOfCursor,
+
+            "a"                     => Instr::Append,
+            "A"                     => Instr::AppendEnd,
+            "i"                     => Instr::Insert,
+            "I"                     => Instr::InsertStart,
+
+            _                       => Instr::Noop,
+        },
+        _                           => vi_common(&token),
     }
 }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -22,6 +22,7 @@ pub enum Instr {
     AppendEnd,
     NormalMode,
     ReplaceMode,
+    Digit(u32),
     Done,
     Cancel,
     Clear,
@@ -101,7 +102,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "j"                     => Instr::HistoryNext,
             "k"                     => Instr::HistoryPrev,
             "l"                     => Instr::MoveCursorRight,
-            "0"                     => Instr::MoveCursorStart,
+            "0"                     => Instr::Digit(0),
             "$"                     => Instr::MoveCursorEnd,
 
             "x"                     => Instr::DeleteCharRightOfCursor,
@@ -114,6 +115,16 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "A"                     => Instr::AppendEnd,
             "i"                     => Instr::Insert,
             "I"                     => Instr::InsertStart,
+
+            "1"                     => Instr::Digit(1),
+            "2"                     => Instr::Digit(2),
+            "3"                     => Instr::Digit(3),
+            "4"                     => Instr::Digit(4),
+            "5"                     => Instr::Digit(5),
+            "6"                     => Instr::Digit(6),
+            "7"                     => Instr::Digit(7),
+            "8"                     => Instr::Digit(8),
+            "9"                     => Instr::Digit(9),
 
             _                       => Instr::Noop,
         },

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -8,6 +8,7 @@ pub enum Instr {
     MoveCursorStart,
     MoveCursorEnd,
     MoveEndOfWordRight,
+    MoveEndOfWordWsRight,
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
@@ -110,6 +111,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "r"                     => Instr::ReplaceMode,
 
             "e"                     => Instr::MoveEndOfWordRight,
+            "E"                     => Instr::MoveEndOfWordWsRight,
 
             "a"                     => Instr::Append,
             "A"                     => Instr::AppendEnd,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -7,6 +7,7 @@ pub enum Instr {
     MoveCursorRight,
     MoveCursorStart,
     MoveCursorEnd,
+    MoveEndOfWordRight,
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
@@ -100,6 +101,8 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "$"                     => Instr::MoveCursorEnd,
 
             "x"                     => Instr::DeleteCharRightOfCursor,
+
+            "e"                     => Instr::MoveEndOfWordRight,
 
             "a"                     => Instr::Append,
             "A"                     => Instr::AppendEnd,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -37,6 +37,7 @@ pub enum Instr {
     DeleteMode,
     Digit(u32),
     Done,
+    DoneOrEof,
     Cancel,
     Clear,
     Noop
@@ -93,11 +94,10 @@ fn emacs_mode(token: parser::Token) -> Instr {
 fn vi_common(token: &parser::Token) -> Instr {
     match *token {
         parser::Token::Enter        => Instr::Done,
+        parser::Token::CtrlD        => Instr::DoneOrEof,
         parser::Token::Esc          => Instr::NormalMode,
         parser::Token::Backspace    => Instr::DeleteCharLeftOfCursor,
         parser::Token::EscBracket3T => Instr::DeleteCharRightOfCursor,
-        // XXX EOF
-        parser::Token::CtrlD        => Instr::DeleteCharRightOfCursorOrEOF,
         // movement keys
         parser::Token::EscBracketA  => Instr::HistoryPrev,
         parser::Token::EscBracketB  => Instr::HistoryNext,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -181,11 +181,12 @@ fn vi_replace_mode(token: parser::Token) -> Instr {
 }
 fn vi_move_char_mode(move_type: CharMoveType, token: parser::Token) -> Instr {
     match token {
-        parser::Token::Text(ref text) if text.chars().count() == 1 => match move_type {
-            CharMoveType::BeforeLeft  => Instr::MoveBeforeCharLeft(text.chars().next().unwrap()),
-            CharMoveType::BeforeRight => Instr::MoveBeforeCharRight(text.chars().next().unwrap()),
-            CharMoveType::Left        => Instr::MoveCharLeft(text.chars().next().unwrap()),
-            CharMoveType::Right       => Instr::MoveCharRight(text.chars().next().unwrap()),
+        parser::Token::Text(ref text) => match (move_type, text.chars().next()) {
+            (CharMoveType::BeforeLeft, Some(c))  => Instr::MoveBeforeCharLeft(c),
+            (CharMoveType::BeforeRight, Some(c)) => Instr::MoveBeforeCharRight(c),
+            (CharMoveType::Left, Some(c))        => Instr::MoveCharLeft(c),
+            (CharMoveType::Right, Some(c))       => Instr::MoveCharRight(c),
+            (_, None)                            => Instr::NormalMode, // this is probably unreachable!()
         },
         _                           => Instr::NormalMode,
     }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -183,7 +183,33 @@ fn vi_move_char_mode(move_type: CharMoveType, token: parser::Token) -> Instr {
 fn vi_delete_mode(token: parser::Token) -> Instr {
     match token {
         parser::Token::Text(text)   => match text.as_ref() {
+            "h"                     => Instr::MoveCursorLeft,
+            "l"                     => Instr::MoveCursorRight,
+            "0"                     => Instr::Digit(0),
+            "$"                     => Instr::MoveCursorEnd,
+
             "d"                     => Instr::DeleteLine,
+
+            "e"                     => Instr::MoveEndOfWordRight,
+            "E"                     => Instr::MoveEndOfWordWsRight,
+            "w"                     => Instr::MoveWordRight,
+            "W"                     => Instr::MoveWordWsRight,
+            "b"                     => Instr::MoveWordLeft,
+            "B"                     => Instr::MoveWordWsLeft,
+            "t"                     => Instr::MoveCharMode(CharMoveType::BeforeRight),
+            "T"                     => Instr::MoveCharMode(CharMoveType::BeforeLeft),
+            "f"                     => Instr::MoveCharMode(CharMoveType::Right),
+            "F"                     => Instr::MoveCharMode(CharMoveType::Left),
+
+            "1"                     => Instr::Digit(1),
+            "2"                     => Instr::Digit(2),
+            "3"                     => Instr::Digit(3),
+            "4"                     => Instr::Digit(4),
+            "5"                     => Instr::Digit(5),
+            "6"                     => Instr::Digit(6),
+            "7"                     => Instr::Digit(7),
+            "8"                     => Instr::Digit(8),
+            "9"                     => Instr::Digit(9),
             _                       => Instr::NormalMode,
         },
         _                           => Instr::NormalMode,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -20,6 +20,7 @@ pub enum Instr {
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
+    DeleteLine,
     Substitute,
     InsertAtCursor(String),
     ReplaceAtCursor(String),
@@ -181,6 +182,10 @@ fn vi_move_char_mode(move_type: CharMoveType, token: parser::Token) -> Instr {
 }
 fn vi_delete_mode(token: parser::Token) -> Instr {
     match token {
+        parser::Token::Text(text)   => match text.as_ref() {
+            "d"                     => Instr::DeleteLine,
+            _                       => Instr::NormalMode,
+        },
         _                           => Instr::NormalMode,
     }
 }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -1,5 +1,5 @@
 use parser;
-use edit::EditMode;
+use edit::ModeState;
 use edit::ViMode;
 
 pub enum Instr {
@@ -54,19 +54,17 @@ pub enum CharMoveType {
     Left,
 }
 
-pub fn interpret_token(token: parser::Token, edit_mode: EditMode, vi_mode: ViMode) -> Instr {
-    match edit_mode {
-        EditMode::Emacs => emacs_mode(token),
-        EditMode::Vi => match vi_mode {
-            ViMode::Insert => vi_insert_mode(token),
-            ViMode::Normal => vi_normal_mode(token),
-            ViMode::Replace => vi_replace_mode(token),
-            ViMode::MoveChar(move_type) => vi_move_char_mode(move_type, token),
-            ViMode::DeleteMoveChar(move_type) => vi_move_char_mode(move_type, token),
-            ViMode::ChangeMoveChar(move_type) => vi_move_char_mode(move_type, token),
-            ViMode::Delete => vi_delete_mode(token),
-            ViMode::Change => vi_change_mode(token),
-        },
+pub fn interpret_token(token: parser::Token, edit_mode_state: ModeState) -> Instr {
+    match edit_mode_state {
+        ModeState::Emacs => emacs_mode(token),
+        ModeState::Vi(ViMode::Insert, _) => vi_insert_mode(token),
+        ModeState::Vi(ViMode::Normal, _) => vi_normal_mode(token),
+        ModeState::Vi(ViMode::Replace, _) => vi_replace_mode(token),
+        ModeState::Vi(ViMode::MoveChar(move_type), _) => vi_move_char_mode(move_type, token),
+        ModeState::Vi(ViMode::DeleteMoveChar(move_type), _) => vi_move_char_mode(move_type, token),
+        ModeState::Vi(ViMode::ChangeMoveChar(move_type), _) => vi_move_char_mode(move_type, token),
+        ModeState::Vi(ViMode::Delete, _) => vi_delete_mode(token),
+        ModeState::Vi(ViMode::Change, _) => vi_change_mode(token),
     }
 }
 

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -9,6 +9,7 @@ pub enum Instr {
     MoveCursorEnd,
     MoveEndOfWordRight,
     MoveEndOfWordWsRight,
+    MoveWordRight,
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
@@ -112,6 +113,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
 
             "e"                     => Instr::MoveEndOfWordRight,
             "E"                     => Instr::MoveEndOfWordWsRight,
+            "w"                     => Instr::MoveWordRight,
 
             "a"                     => Instr::Append,
             "A"                     => Instr::AppendEnd,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -13,6 +13,7 @@ pub enum Instr {
     DeleteCharRightOfCursorOrEOF,
     Substitute,
     InsertAtCursor(String),
+    ReplaceAtCursor(String),
     HistoryNext,
     HistoryPrev,
     Insert,
@@ -20,6 +21,7 @@ pub enum Instr {
     Append,
     AppendEnd,
     NormalMode,
+    ReplaceMode,
     Done,
     Cancel,
     Clear,
@@ -32,6 +34,7 @@ pub fn interpret_token(token: parser::Token, edit_mode: EditMode, vi_mode: ViMod
         EditMode::Vi => match vi_mode {
             ViMode::Insert => vi_insert_mode(token),
             ViMode::Normal => vi_normal_mode(token),
+            ViMode::Replace => vi_replace_mode(token),
         },
     }
 }
@@ -103,6 +106,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
 
             "x"                     => Instr::DeleteCharRightOfCursor,
             "s"                     => Instr::Substitute,
+            "r"                     => Instr::ReplaceMode,
 
             "e"                     => Instr::MoveEndOfWordRight,
 
@@ -114,5 +118,11 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             _                       => Instr::Noop,
         },
         _                           => vi_common(&token),
+    }
+}
+fn vi_replace_mode(token: parser::Token) -> Instr {
+    match token {
+        parser::Token::Text(text)   => Instr::ReplaceAtCursor(text),
+        _                           => Instr::NormalMode,
     }
 }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -11,6 +11,7 @@ pub enum Instr {
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
+    Substitute,
     InsertAtCursor(String),
     HistoryNext,
     HistoryPrev,
@@ -101,6 +102,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "$"                     => Instr::MoveCursorEnd,
 
             "x"                     => Instr::DeleteCharRightOfCursor,
+            "s"                     => Instr::Substitute,
 
             "e"                     => Instr::MoveEndOfWordRight,
 

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -10,6 +10,7 @@ pub enum Instr {
     MoveEndOfWordRight,
     MoveEndOfWordWsRight,
     MoveWordRight,
+    MoveWordWsRight,
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
@@ -114,6 +115,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "e"                     => Instr::MoveEndOfWordRight,
             "E"                     => Instr::MoveEndOfWordWsRight,
             "w"                     => Instr::MoveWordRight,
+            "W"                     => Instr::MoveWordWsRight,
 
             "a"                     => Instr::Append,
             "A"                     => Instr::AppendEnd,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -32,6 +32,7 @@ pub enum Instr {
     NormalMode,
     ReplaceMode,
     MoveCharMode(CharMoveType),
+    DeleteMode,
     Digit(u32),
     Done,
     Cancel,
@@ -55,6 +56,7 @@ pub fn interpret_token(token: parser::Token, edit_mode: EditMode, vi_mode: ViMod
             ViMode::Normal => vi_normal_mode(token),
             ViMode::Replace => vi_replace_mode(token),
             ViMode::MoveChar(move_type) => vi_move_char_mode(move_type, token),
+            ViMode::Delete => vi_delete_mode(token),
         },
     }
 }
@@ -127,6 +129,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "x"                     => Instr::DeleteCharRightOfCursor,
             "s"                     => Instr::Substitute,
             "r"                     => Instr::ReplaceMode,
+            "d"                     => Instr::DeleteMode,
 
             "e"                     => Instr::MoveEndOfWordRight,
             "E"                     => Instr::MoveEndOfWordWsRight,
@@ -173,6 +176,11 @@ fn vi_move_char_mode(move_type: CharMoveType, token: parser::Token) -> Instr {
             CharMoveType::Left        => Instr::MoveCharLeft(text.chars().next().unwrap()),
             CharMoveType::Right       => Instr::MoveCharRight(text.chars().next().unwrap()),
         },
+        _                           => Instr::NormalMode,
+    }
+}
+fn vi_delete_mode(token: parser::Token) -> Instr {
+    match token {
         _                           => Instr::NormalMode,
     }
 }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -57,6 +57,7 @@ pub fn interpret_token(token: parser::Token, edit_mode: EditMode, vi_mode: ViMod
             ViMode::Normal => vi_normal_mode(token),
             ViMode::Replace => vi_replace_mode(token),
             ViMode::MoveChar(move_type) => vi_move_char_mode(move_type, token),
+            ViMode::DeleteMoveChar(move_type) => vi_move_char_mode(move_type, token),
             ViMode::Delete => vi_delete_mode(token),
         },
     }

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -21,6 +21,7 @@ pub enum Instr {
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
     DeleteLine,
+    DeleteToEnd,
     Substitute,
     InsertAtCursor(String),
     ReplaceAtCursor(String),
@@ -132,6 +133,7 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "s"                     => Instr::Substitute,
             "r"                     => Instr::ReplaceMode,
             "d"                     => Instr::DeleteMode,
+            "D"                     => Instr::DeleteToEnd,
 
             "e"                     => Instr::MoveEndOfWordRight,
             "E"                     => Instr::MoveEndOfWordWsRight,

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -11,6 +11,8 @@ pub enum Instr {
     MoveEndOfWordWsRight,
     MoveWordRight,
     MoveWordWsRight,
+    MoveWordLeft,
+    MoveWordWsLeft,
     DeleteCharLeftOfCursor,
     DeleteCharRightOfCursor,
     DeleteCharRightOfCursorOrEOF,
@@ -116,6 +118,8 @@ fn vi_normal_mode(token: parser::Token) -> Instr {
             "E"                     => Instr::MoveEndOfWordWsRight,
             "w"                     => Instr::MoveWordRight,
             "W"                     => Instr::MoveWordWsRight,
+            "b"                     => Instr::MoveWordLeft,
+            "B"                     => Instr::MoveWordWsLeft,
 
             "a"                     => Instr::Append,
             "A"                     => Instr::AppendEnd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl Copperline {
             return Err(Error::UnsupportedTerm);
         }
         let mut io = try!(self.term.acquire_io());
-        let ctx = EditCtx::new(prompt, &self.history, enc);
+        let ctx = EditCtx::new(prompt, &self.history, enc, self.mode);
         let res = run::run(ctx, &mut io);
         drop(io);
         println!("");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,13 @@ pub use error::Error;
 use history::History;
 use term::Term;
 use edit::EditCtx;
+pub use edit::EditMode;
 use run::RunIO;
 
 pub struct Copperline {
     term: Term,
-    history: History
+    history: History,
+    mode: EditMode,
 }
 
 impl Copperline {
@@ -65,8 +67,15 @@ impl Copperline {
     pub fn new_from_raw_fds(ifd: RawFd, ofd: RawFd) -> Copperline {
         Copperline {
             term: Term::new(ifd, ofd),
-            history: History::new()
+            history: History::new(),
+            // start in emacs mode by default
+            mode: EditMode::Emacs,
         }
+    }
+
+    /// Set the editing mode.
+    pub fn set_edit_mode(&mut self, mode: EditMode) {
+        self.mode = mode;
     }
 
     /// Reads a line from the input using the specified prompt.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -153,7 +153,7 @@ fn parse_esc(vec: &[u8]) -> ParseResult<Token> {
 pub fn parse(vec: &[u8], enc: EncodingRef) -> ParseResult<Token> {
     let i = try!(parse_char(vec, 0)).0;
     match match_head(i) {
-        Some(Token::Esc) => parse_esc(vec),
+        Some(Token::Esc) if vec.len() > 1 => parse_esc(vec),
         Some(t) => Ok(ParseSuccess(t, 1)),
         None => {
             let mut dec = enc.raw_decoder();

--- a/src/run.rs
+++ b/src/run.rs
@@ -130,4 +130,17 @@ mod test {
         assert_eq!(run_edit(ctx, &mut io), Ok("ABC".to_string()));
     }
 
+    /// Make sure integers don't overflow in vi mode when using large command counts.
+    #[test]
+    fn no_integer_overflow() {
+        let mut input_vec = vec![27];
+        for _ in 0..50 {
+            input_vec.push('9' as u8);
+        }
+        input_vec.push(13);
+        let mut io = TestIO { input: input_vec, output: vec![] };
+        let h = History::new();
+        let ctx = EditCtx::new("foo> ", &h, ASCII, EditMode::Vi);
+        assert_eq!(run_edit(ctx, &mut io), Ok("".to_string()));
+    }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -95,6 +95,15 @@ mod test {
                 Err(Error::EndOfFile)
             }
         }
+
+        fn read_seq(&mut self) -> Result<Vec<u8>, Error> {
+            // XXX return more than one byte
+            if self.input.len() > 0 {
+                Ok(vec![self.input.remove(0)])
+            } else {
+                Err(Error::EndOfFile)
+            }
+        }
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -185,6 +185,11 @@ mod test {
         test_vi_cmds!("this is a test\x1bcF  real tes\x0d", "this is a real test");
         test_vi_cmds!("this is a test\x1bbbD\x0d", "this is ");
         test_vi_cmds!("this is a test\x1bbbCsome test\x0d", "this is some test");
+        test_vi_cmds!("this is a test\x1bbbcwsome\x0d", "this is some test");
+        test_vi_cmds!("these are some tests\x1bbbcwthe\x0d", "these are the tests");
+        test_vi_cmds!("this is a  test\x1bbbcwsome\x0d", "this is some  test");
+        test_vi_cmds!("this is a  test\x1bbhcwgood \x0d", "this is a good test");
+        test_vi_cmds!("this is a test\x1bbcwthing\x0d", "this is a thing");
         test_vi_cmds!("delete everything\x1bdd\x0d", "");
         test_vi_cmds!("delete everything\x1bccchange everything\x0d", "change everything");
         test_vi_cmds!("this is a test\x1bbc2T some \x0d", "this is some test");

--- a/src/run.rs
+++ b/src/run.rs
@@ -72,6 +72,7 @@ mod test {
     use super::super::edit::EditCtx;
     use super::super::history::History;
     use super::{RunIO, run_edit};
+    use edit::EditMode;
 
     pub struct TestIO {
         input: Vec<u8>,
@@ -96,7 +97,7 @@ mod test {
     fn error_eof_on_empty_input() {
         let mut io = TestIO { input: vec![], output: vec![] };
         let h = History::new();
-        let ctx = EditCtx::new("foo> ", &h, ASCII);
+        let ctx = EditCtx::new("foo> ", &h, ASCII, EditMode::Emacs);
         assert_eq!(run_edit(ctx, &mut io), Err(Error::EndOfFile));
     }
 
@@ -104,7 +105,7 @@ mod test {
     fn ok_empty_after_return() {
         let mut io = TestIO { input: vec![13], output: vec![] };
         let h = History::new();
-        let ctx = EditCtx::new("foo> ", &h, ASCII);
+        let ctx = EditCtx::new("foo> ", &h, ASCII, EditMode::Emacs);
         assert_eq!(run_edit(ctx, &mut io), Ok("".to_string()));
     }
 
@@ -112,7 +113,7 @@ mod test {
     fn ok_ascii_after_return() {
         let mut io = TestIO { input: vec![65, 66, 67, 13], output: vec![] };
         let h = History::new();
-        let ctx = EditCtx::new("foo> ", &h, ASCII);
+        let ctx = EditCtx::new("foo> ", &h, ASCII, EditMode::Emacs);
         assert_eq!(run_edit(ctx, &mut io), Ok("ABC".to_string()));
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,10 +7,11 @@ pub trait RunIO {
 
     fn write(&mut self, Vec<u8>) -> Result<(), Error>;
     fn read_byte(&mut self) -> Result<u8, Error>;
+    fn read_seq(&mut self) -> Result<Vec<u8>, Error>;
 
-    fn prompt(&mut self, w: Vec<u8>) -> Result<u8, Error> {
+    fn prompt(&mut self, w: Vec<u8>) -> Result<Vec<u8>, Error> {
         try!(self.write(w));
-        self.read_byte()
+        self.read_seq()
     }
 
 }
@@ -52,7 +53,10 @@ fn run_edit<'a>(mut ctx: EditCtx<'a>, io: &mut RunIO) -> Result<String, Error> {
     loop {
         match edit(&mut ctx) {
             EditResult::Cont(line) => {
-                ctx.fill(try!(io.prompt(line)));
+                let bytes = try!(io.prompt(line));
+                for byte in bytes.iter() {
+                    ctx.fill(*byte);
+                }
             },
             EditResult::Halt(res) => { return res; }
         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -182,7 +182,11 @@ mod test {
         test_vi_cmds!("this is a test\x1b0d2fi\x0d", "s a test");
         test_vi_cmds!("this is a test\x1bdT \x0d", "this is a t");
         test_vi_cmds!("this is a test\x1bdF \x0d", "this is at");
+        test_vi_cmds!("this is a test\x1bcF  real tes\x0d", "this is a real test");
         test_vi_cmds!("this is a test\x1bbbD\x0d", "this is ");
+        test_vi_cmds!("this is a test\x1bbbCsome test\x0d", "this is some test");
         test_vi_cmds!("delete everything\x1bdd\x0d", "");
+        test_vi_cmds!("delete everything\x1bccchange everything\x0d", "change everything");
+        test_vi_cmds!("this is a test\x1bbc2T some \x0d", "this is some test");
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -26,6 +26,15 @@ impl<'a> RunIO for TermIO<'a> {
         let read = try!(self.in_term.read_byte());
         read.ok_or(Error::EndOfFile)
     }
+    fn read_seq(&mut self) -> Result<Vec<u8>, Error> {
+        let read = try!(self.in_term.read_seq());
+        if read.len() == 0 {
+            Err(Error::EndOfFile)
+        }
+        else {
+            Ok(read)
+        }
+    }
 }
 
 pub struct RawMode {
@@ -111,6 +120,17 @@ impl Term {
             return Ok(None);
         }
         Ok(Some(input[0]))
+    }
+
+    /// Attempt to read 3 bytes from the terminal.
+    pub fn read_seq(&mut self) -> Result<Vec<u8>, nix::Error> {
+        let mut input = vec![0u8; 3];
+        let n = try!(read(self.in_fd, &mut input[..]));
+        unsafe {
+            assert!(n <= input.len());
+            input.set_len(n);
+        }
+        Ok(input)
     }
 
 }


### PR DESCRIPTION
This change implements support for vi mode. This includes support for most movement and deletion commands.

Supported features:
- Insert and normal mode
- Movement commands: `h`, `j`, `k`, `l`, `t`, `f`, `T`, `F`, `w`, `W`, `e`, `E`, `b`, `B`
- Change commands: `r`, `s`, `cw` etc
- Deletion (`dw` etc)
- Limited count support (works for moves, won't repeat insertions)

Missing features:
- This has not been properly tested with unicode, though it should be trivial to extend the included tests for unicode.
- Multi line editing doesn't work.
- Registers (i.e. copy and paste)
- Vim text objects
- Movement using `%`
- The `~` command
- `g` commands
